### PR TITLE
efactor Docker mount to use project root

### DIFF
--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -414,7 +414,7 @@ function M.setup(opts)
     end
     vim.schedule(function()
       Utils.info("Starting Rag Service ...")
-      RagService.launch_rag_service(add_resource_with_delay)
+      RagService.launch_rag_service(add_resource_with_delay, Utils.get_project_root())
     end)
   end
 


### PR DESCRIPTION
Updated the Docker run command to mount only the project root instead of the entire host root.
This change enhances security by limiting the container's access to only the necessary project files,
reducing potential exposure to sensitive host data. Adjusted URI conversion functions to align with the
new mount path, ensuring consistent file path handling between the host and container.
